### PR TITLE
🔧 chore : GitHub PR tasks 미완료된 경우 tasks-pending 라벨 자동으로 붙이도록 설정

### DIFF
--- a/.github/workflows/checklist-labeler.yml
+++ b/.github/workflows/checklist-labeler.yml
@@ -1,0 +1,42 @@
+name: PR Checklist Labeler
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-checklist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+
+      - name: Check checklist in PR body
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const hasUnchecked = body.includes('- [ ]');
+            const label = 'tasks-pending';
+            const prNumber = context.payload.pull_request.number;
+
+            if (hasUnchecked) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: [label]
+              });
+            } else {
+              // 체크리스트 다 했으면 라벨 제거
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: label
+                });
+              } catch (error) {
+                // 라벨 없으면 무시
+              }
+            }


### PR DESCRIPTION
### 🔧 작업 내용
- [x] 미완료 task 관리를 위하여 자동 라벨링 설정

### 📌 참고 사항
- [x] 깃 PR Close에서 'tasks-pending'검색시 미완료 Task 검색가능