### PR TITLE
✨ feature : 스프링 시큐리티 로그인 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,16 @@ dependencies {
 	// 순수 Spring 보안 관련 의존성 직접 추가
 	implementation 'org.springframework.security:spring-security-crypto:5.8.5' // Spring 5.3.27에 맞는 버전
 
+	// Spring Security core dependencies
+	implementation 'org.springframework.security:spring-security-web:5.8.5'
+	implementation 'org.springframework.security:spring-security-config:5.8.5'
+
 	// 🔄 객체 매핑 도구
 	// ModelMapper for DTO <-> Entity mapping
 	implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.1.1'
 
 	testImplementation 'org.assertj:assertj-core:3.24.2'
+	testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
 
 	// 📦 JSON 파싱 라이브러리
 	// JSON processing libraries (Jackson, org.json)

--- a/src/main/java/com/wareflow/buildify/config/SecurityConfig.java
+++ b/src/main/java/com/wareflow/buildify/config/SecurityConfig.java
@@ -29,24 +29,19 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf().disable()
-
-                .authorizeHttpRequests()
-//                .requestMatchers("/login", "/signup", "/css/**", "/js/**", "/images/**").permitAll()
-                // 개발 단계 한정
-                .requestMatchers("/**").permitAll()
-                .requestMatchers("/admin/**").hasRole("ADMIN")
-                .requestMatchers("/user/**").hasRole("USER")
+                .authorizeRequests()  // ✅ 요거 중요!!
+                .antMatchers("/login", "/signup", "/css/**", "/js/**", "/images/**").permitAll()
+                .antMatchers("/admin/**").hasRole("ADMIN")
+                .antMatchers("/user/**").hasRole("USER")
                 .anyRequest().authenticated()
                 .and()
-
                 .formLogin()
                 .loginPage("/login")
                 .loginProcessingUrl("/login")
-                .successHandler(customSuccessHandler()) // 로그인 성공 후 분기처리
+                .successHandler(customSuccessHandler())
                 .failureUrl("/login?error=true")
                 .permitAll()
                 .and()
-
                 .logout()
                 .logoutUrl("/logout")
                 .logoutSuccessUrl("/login?logout")

--- a/src/main/java/com/wareflow/buildify/config/SecurityConfig.java
+++ b/src/main/java/com/wareflow/buildify/config/SecurityConfig.java
@@ -2,13 +2,85 @@ package com.wareflow.buildify.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+    // 🔐 비밀번호 암호화용 빈 등록 (회원가입, 로그인 비교 등에 사용)
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // 🔐 보안 필터 체인 설정
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+
+                .authorizeHttpRequests()
+//                .requestMatchers("/login", "/signup", "/css/**", "/js/**", "/images/**").permitAll()
+                // 개발 단계 한정
+                .requestMatchers("/**").permitAll()
+                .requestMatchers("/admin/**").hasRole("ADMIN")
+                .requestMatchers("/user/**").hasRole("USER")
+                .anyRequest().authenticated()
+                .and()
+
+                .formLogin()
+                .loginPage("/login")
+                .loginProcessingUrl("/login")
+                .successHandler(customSuccessHandler()) // 로그인 성공 후 분기처리
+                .failureUrl("/login?error=true")
+                .permitAll()
+                .and()
+
+                .logout()
+                .logoutUrl("/logout")
+                .logoutSuccessUrl("/login?logout")
+                .permitAll();
+
+        return http.build();
+    }
+
+    // ✅ 로그인 성공 시 ROLE에 따라 리다이렉트 처리
+    @Bean
+    public AuthenticationSuccessHandler customSuccessHandler() {
+        return new AuthenticationSuccessHandler() {
+            @Override
+            public void onAuthenticationSuccess(
+                    HttpServletRequest request,
+                    HttpServletResponse response,
+                    Authentication authentication
+            ) throws IOException {
+
+                for (GrantedAuthority auth : authentication.getAuthorities()) {
+                    String role = auth.getAuthority();
+
+                    if ("ROLE_ADMIN".equals(role)) {
+                        response.sendRedirect("/admin/home");
+                        return;
+                    } else if ("ROLE_USER".equals(role)) {
+                        response.sendRedirect("/user/home");
+                        return;
+                    }
+                }
+
+                // 예외적으로 아무 권한도 없을 때
+                response.sendRedirect("/login?error=no_role");
+            }
+        };
     }
 }

--- a/src/main/java/com/wareflow/buildify/domain/admin/home/AdminHomeController.java
+++ b/src/main/java/com/wareflow/buildify/domain/admin/home/AdminHomeController.java
@@ -1,5 +1,6 @@
 package com.wareflow.buildify.domain.user.home;
 
+import com.wareflow.buildify.domain.auth.login.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,7 +19,7 @@ public class AdminHomeController {
 //    private final InventoryService inventoryService;
 
     @GetMapping
-    public String home(@AuthenticationPrincipal UserDetails user, Model model) {
+    public String home(@AuthenticationPrincipal CustomUserDetails user, Model model) {
         // 타 도메인 서비스 계층의 기능을 들여와서 대시보드 보여주면 될듯
 //        int todayInbound = inboundService.countToday(user.getClientId());
 //        int todayOutbound = outboundService.countToday(user.getClientId());

--- a/src/main/java/com/wareflow/buildify/domain/admin/home/AdminHomeController.java
+++ b/src/main/java/com/wareflow/buildify/domain/admin/home/AdminHomeController.java
@@ -1,0 +1,33 @@
+package com.wareflow.buildify.domain.user.home;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/home")
+public class AdminHomeController {
+
+//    private final InboundService inboundService;
+//    private final OutboundService outboundService;
+//    private final InventoryService inventoryService;
+
+    @GetMapping
+    public String home(@AuthenticationPrincipal UserDetails user, Model model) {
+        // 타 도메인 서비스 계층의 기능을 들여와서 대시보드 보여주면 될듯
+//        int todayInbound = inboundService.countToday(user.getClientId());
+//        int todayOutbound = outboundService.countToday(user.getClientId());
+//        int totalStock = inventoryService.getTotalStock(user.getClientId());
+//
+//        model.addAttribute("inboundCount", todayInbound);
+//        model.addAttribute("outboundCount", todayOutbound);
+//        model.addAttribute("stock", totalStock);
+
+        return "admin/home";
+    }
+}

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/controller/LoginController.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/controller/LoginController.java
@@ -1,4 +1,14 @@
 package com.wareflow.buildify.domain.auth.login.controller;
 
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@Log4j2
 public class LoginController {
+    @GetMapping("/login")
+    public String login() {
+        return "/login";
+    }
 }

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/mapper/AdminLoginMapper.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/mapper/AdminLoginMapper.java
@@ -1,0 +1,9 @@
+package com.wareflow.buildify.domain.auth.login.mapper;
+
+import com.wareflow.buildify.vo.AdminVO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AdminLoginMapper {
+    AdminVO findById(String adminId);
+}

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/mapper/AuthMapper.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/mapper/AuthMapper.java
@@ -1,0 +1,9 @@
+package com.wareflow.buildify.domain.auth.login.mapper;
+
+import com.wareflow.buildify.vo.AuthVO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AuthMapper {
+    AuthVO findById(String id);
+}

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/mapper/LoginMapper.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/mapper/LoginMapper.java
@@ -1,4 +1,0 @@
-package com.wareflow.buildify.domain.auth.login.mapper;
-
-public interface LoginMapper {
-}

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/mapper/UserLoginMapper.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/mapper/UserLoginMapper.java
@@ -1,0 +1,9 @@
+package com.wareflow.buildify.domain.auth.login.mapper;
+
+import com.wareflow.buildify.vo.UserVO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserLoginMapper {
+    UserVO findById(String userId);
+}

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/security/CustomUserDetails.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/security/CustomUserDetails.java
@@ -1,0 +1,41 @@
+package com.wareflow.buildify.domain.auth.login.security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final String id;
+    private final String password;
+    private final String role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return id;
+    }
+
+    // 계정 상태 관련 설정 (true로 고정)
+    @Override public boolean isAccountNonExpired()     { return true; }
+    @Override public boolean isAccountNonLocked()      { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled()               { return true; }
+
+}

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/security/CustomUserDetails.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/security/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.wareflow.buildify.domain.auth.login.security;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
@@ -16,6 +17,19 @@ public class CustomUserDetails implements UserDetails {
     private final String id;
     private final String password;
     private final String role;
+
+    private String clientId;    // ✅ 추가 (User일 경우)
+    private String adminNumber; // ✅ 추가 (Admin일 경우)
+
+    @Builder
+    public CustomUserDetails(String id, String password, String role,
+                             String clientId, String adminNumber) {
+        this.id = id;
+        this.password = password;
+        this.role = role;
+        this.clientId = clientId;
+        this.adminNumber = adminNumber;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/security/CustomUserDetailsService.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/security/CustomUserDetailsService.java
@@ -1,0 +1,55 @@
+package com.wareflow.buildify.domain.auth.login.security;
+
+import com.wareflow.buildify.domain.auth.login.mapper.AdminLoginMapper;
+import com.wareflow.buildify.domain.auth.login.mapper.AuthMapper;
+import com.wareflow.buildify.domain.auth.login.mapper.UserLoginMapper;
+import com.wareflow.buildify.vo.AdminVO;
+import com.wareflow.buildify.vo.AuthVO;
+import com.wareflow.buildify.vo.UserVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final AuthMapper authMapper;
+    private final UserLoginMapper userLoginMapper;
+    private final AdminLoginMapper adminLoginMapper;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        log.info("🟢 로그인 시도: {}", id);
+
+        // 1️⃣ auth 테이블에서 id와 role 확인
+        AuthVO authVO = authMapper.findById(id);
+        if (authVO == null) {
+            throw new UsernameNotFoundException("존재하지 않는 아이디입니다.");
+        }
+
+        String role = authVO.getRole();
+
+        if(role.equals("0")){
+            UserVO user = userLoginMapper.findById(id);
+            if (user == null) {
+
+                throw new UsernameNotFoundException("사용자 정보가 존재하지 않습니다.");
+            }
+
+            return new CustomUserDetails(user.getUserId(), user.getUserPw(), "ROLE_USER");
+        } else {
+            // 관리자
+            AdminVO admin = adminLoginMapper.findById(id);
+            if (admin == null) {
+                throw new UsernameNotFoundException("관리자 정보가 존재하지 않습니다.");
+            }
+            return new CustomUserDetails(admin.getAdminId(), admin.getAdminPassword(), "ROLE_ADMIN");
+        }
+
+    }
+}

--- a/src/main/java/com/wareflow/buildify/domain/auth/login/security/CustomUserDetailsService.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/login/security/CustomUserDetailsService.java
@@ -41,14 +41,25 @@ public class CustomUserDetailsService implements UserDetailsService {
                 throw new UsernameNotFoundException("사용자 정보가 존재하지 않습니다.");
             }
 
-            return new CustomUserDetails(user.getUserId(), user.getUserPw(), "ROLE_USER");
+            return CustomUserDetails.builder()
+                    .id(user.getUserId())
+                    .password(user.getUserPw())
+                    .role("ROLE_USER")
+                    .clientId(user.getClientId())
+                    .build();
         } else {
             // 관리자
             AdminVO admin = adminLoginMapper.findById(id);
             if (admin == null) {
                 throw new UsernameNotFoundException("관리자 정보가 존재하지 않습니다.");
             }
-            return new CustomUserDetails(admin.getAdminId(), admin.getAdminPassword(), "ROLE_ADMIN");
+
+            return CustomUserDetails.builder()
+                    .id(admin.getAdminId())
+                    .password(admin.getAdminPassword())
+                    .role("ROLE_ADMIN")
+                    .adminNumber(admin.getAdminNumber())
+                    .build();
         }
 
     }

--- a/src/main/java/com/wareflow/buildify/domain/auth/signup/controller/SignupController.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/signup/controller/SignupController.java
@@ -2,7 +2,6 @@ package com.wareflow.buildify.domain.auth.signup.controller;
 
 import com.wareflow.buildify.domain.auth.signup.service.SignupService;
 import com.wareflow.buildify.dto.UserDTO;
-import com.wareflow.buildify.vo.UserVO;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -13,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
-@RequestMapping("/components")
+@RequestMapping("/common/pages")
 @Log4j2
 public class SignupController {
 

--- a/src/main/java/com/wareflow/buildify/domain/auth/signup/mapper/SignupMapper.java
+++ b/src/main/java/com/wareflow/buildify/domain/auth/signup/mapper/SignupMapper.java
@@ -1,9 +1,11 @@
 package com.wareflow.buildify.domain.auth.signup.mapper;
 
 import com.wareflow.buildify.vo.UserVO;
+import org.apache.ibatis.annotations.Mapper;
 
 import java.util.Map;
 
+@Mapper
 public interface SignupMapper {
     int insertUser(UserVO userVO);
     int existCheckByUserId(String userid);

--- a/src/main/java/com/wareflow/buildify/domain/user/home/UserHomeController.java
+++ b/src/main/java/com/wareflow/buildify/domain/user/home/UserHomeController.java
@@ -1,5 +1,6 @@
 package com.wareflow.buildify.domain.user.home;
 
+import com.wareflow.buildify.domain.auth.login.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,7 +19,7 @@ public class UserHomeController {
 //    private final InventoryService inventoryService;
 
     @GetMapping
-    public String home(@AuthenticationPrincipal UserDetails user, Model model) {
+    public String home(@AuthenticationPrincipal CustomUserDetails user, Model model) {
         // 타 도메인 서비스 계층의 기능을 들여와서 대시보드 보여주면 될듯
 //        int todayInbound = inboundService.countToday(user.getClientId());
 //        int todayOutbound = outboundService.countToday(user.getClientId());

--- a/src/main/java/com/wareflow/buildify/domain/user/home/UserHomeController.java
+++ b/src/main/java/com/wareflow/buildify/domain/user/home/UserHomeController.java
@@ -1,0 +1,33 @@
+package com.wareflow.buildify.domain.user.home;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/user/home")
+public class UserHomeController {
+
+//    private final InboundService inboundService;
+//    private final OutboundService outboundService;
+//    private final InventoryService inventoryService;
+
+    @GetMapping
+    public String home(@AuthenticationPrincipal UserDetails user, Model model) {
+        // 타 도메인 서비스 계층의 기능을 들여와서 대시보드 보여주면 될듯
+//        int todayInbound = inboundService.countToday(user.getClientId());
+//        int todayOutbound = outboundService.countToday(user.getClientId());
+//        int totalStock = inventoryService.getTotalStock(user.getClientId());
+//
+//        model.addAttribute("inboundCount", todayInbound);
+//        model.addAttribute("outboundCount", todayOutbound);
+//        model.addAttribute("stock", totalStock);
+
+        return "user/home";
+    }
+}

--- a/src/main/java/com/wareflow/buildify/dto/AdminDTO.java
+++ b/src/main/java/com/wareflow/buildify/dto/AdminDTO.java
@@ -1,4 +1,24 @@
 package com.wareflow.buildify.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AdminDTO {
+    private String adminNumber;
+    private String adminRole;
+    private String adminName;
+    private String adminEmail;
+    private Date adminEnterDate;
+    private String adminAddress;
+    private String adminPhone;
+    private String adminId;
+    private String adminPassword;
 }

--- a/src/main/java/com/wareflow/buildify/dto/AuthDTO.java
+++ b/src/main/java/com/wareflow/buildify/dto/AuthDTO.java
@@ -1,0 +1,16 @@
+package com.wareflow.buildify.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthDTO {
+
+    private String id;
+    private String role;
+}

--- a/src/main/java/com/wareflow/buildify/temp/IndexView.java
+++ b/src/main/java/com/wareflow/buildify/temp/IndexView.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 public class IndexView {
 
-    @GetMapping("/login")
-    public String index() { return "login"; }
+//    @GetMapping("/login")
+//    public String index() { return "login"; }
 
     @GetMapping("/components/charts-chartjs")
     public String chartsChartjs() { return "components/charts-chartjs"; }

--- a/src/main/java/com/wareflow/buildify/vo/AdminVO.java
+++ b/src/main/java/com/wareflow/buildify/vo/AdminVO.java
@@ -1,4 +1,22 @@
 package com.wareflow.buildify.vo;
 
+import lombok.*;
+
+import java.util.Date;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class AdminVO {
+    private String adminNumber;
+    private String adminRole;
+    private String adminName;
+    private String adminEmail;
+    private Date adminEnterDate;
+    private String adminAddress;
+    private String adminPhone;
+    private String adminId;
+    private String adminPassword;
 }

--- a/src/main/java/com/wareflow/buildify/vo/AuthVO.java
+++ b/src/main/java/com/wareflow/buildify/vo/AuthVO.java
@@ -1,0 +1,14 @@
+package com.wareflow.buildify.vo;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class AuthVO {
+
+    private String id;
+    private String role;
+}

--- a/src/main/java/com/wareflow/buildify/vo/UserVO.java
+++ b/src/main/java/com/wareflow/buildify/vo/UserVO.java
@@ -1,9 +1,6 @@
 package com.wareflow.buildify.vo;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -12,6 +9,7 @@ import java.util.Date;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
 public class UserVO {
     private String clientId;
     private String userName;

--- a/src/main/resources/config/mybatis-config.xml
+++ b/src/main/resources/config/mybatis-config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+    <settings>
+        <setting name="mapUnderscoreToCamelCase" value="true"/>
+    </settings>
+</configuration>

--- a/src/main/resources/mappers/auth/AdminLoginMapper.xml
+++ b/src/main/resources/mappers/auth/AdminLoginMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.wareflow.buildify.domain.auth.login.mapper.AdminLoginMapper">
+    <select id="findById" resultType="com.wareflow.buildify.vo.AdminVO">
+        SELECT
+            admin_number,
+            admin_role,
+            admin_name,
+            admin_email,
+            admin_enter_date,
+            admin_address,
+            admin_phone,
+            admin_id,
+            admin_pw
+        FROM admin
+        WHERE admin_id = #{adminId}
+
+    </select>
+</mapper>

--- a/src/main/resources/mappers/auth/AuthMapper.xml
+++ b/src/main/resources/mappers/auth/AuthMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.wareflow.buildify.domain.auth.login.mapper.AuthMapper">
+
+    <select id ="findById" resultType="com.wareflow.buildify.vo.AuthVO">
+        SELECT
+            id, role
+        FROM
+            auth
+        WHERE
+            id = #{id}
+    </select>
+
+</mapper>

--- a/src/main/resources/mappers/auth/LoginMapper.xml
+++ b/src/main/resources/mappers/auth/LoginMapper.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-
-<mapper namespace="com.wareflow.buildify.mapper.LoginMapper">
-    <!-- 여기에 SQL 정의 들어감 -->
-</mapper>

--- a/src/main/resources/mappers/auth/UserLoginMapper.xml
+++ b/src/main/resources/mappers/auth/UserLoginMapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.wareflow.buildify.domain.auth.login.mapper.UserLoginMapper">
+    <select id="findById" resultType="com.wareflow.buildify.vo.UserVO">
+        SELECT
+            client_id,
+            user_name,
+            user_phone,
+            user_email,
+            user_address,
+            business_number,
+            user_enterdate,
+            user_id,
+            user_pw,
+            user_status
+        FROM user
+        WHERE user_id = #{userId}
+
+    </select>
+</mapper>

--- a/src/main/webapp/WEB-INF/root-context.xml
+++ b/src/main/webapp/WEB-INF/root-context.xml
@@ -48,6 +48,7 @@
     <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dataSource"/>
         <property name="mapperLocations" value="classpath:/mappers/**/*.xml"></property>
+        <property name="configLocation" value="classpath:/config/mybatis-config.xml"/>
     </bean>
 
     <tx:annotation-driven transaction-manager="transactionManager" />

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -64,7 +64,7 @@
             margin-bottom: 5px;
         }
 
-        input[type="email"],
+        input[type="text"],
         input[type="password"] {
             width: 100%;
             padding: 10px;
@@ -166,17 +166,17 @@
         }
 
         @media (max-width: 800px) {
-        body {
-            justify-content: center;
-            align-items: center;
-        }
+            body {
+                justify-content: center;
+                align-items: center;
+            }
 
-        .container {
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 30px 20px;
-        }
+            .container {
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                padding: 30px 20px;
+            }
 
             .left,
             .right {
@@ -194,10 +194,9 @@
             .hint-inline {
                 font-size: 0.7rem;
             }
-
         }
 
-            footer {
+        footer {
             text-align: center;
             padding: 20px;
             font-size: 0.9rem;
@@ -213,20 +212,34 @@
     </div>
     <div class="right">
         <h2>로그인</h2>
-        <form>
+        <form action="${pageContext.request.contextPath}/login" method="post">
             <div class="input-label-group">
-                <label for="email">이메일</label>
+                <label for="username">이메일</label>
                 <span class="hint-inline">(올바른 이메일 형식을 입력해주세요)</span>
             </div>
-            <input type="email" id="email" placeholder="example@email.com" required>
+            <input type="text" id="username" name="username" placeholder="아이디를 입력하세요." required>
 
             <div class="input-label-group">
                 <label for="password">비밀번호</label>
                 <span class="hint-inline">(영문, 숫자, 특수문자 포함 8~15자)</span>
             </div>
-            <input type="password" id="password" placeholder="비밀번호를 입력하세요" required>
+            <input type="password" id="password" name="password" placeholder="비밀번호를 입력하세요" required>
+
+            <div style="margin: 10px 0;">
+                <input type="checkbox" id="remember-me" name="remember-me" />
+                <label for="remember-me">로그인 유지</label>
+            </div>
 
             <button type="submit">로그인</button>
+
+            <c:if test="${param.error == 'true'}">
+                <p style="color: red;">아이디 또는 비밀번호가 올바르지 않습니다.</p>
+            </c:if>
+
+            <c:if test="${param.logout == 'true'}">
+                <p style="color: green;">성공적으로 로그아웃 되었습니다.</p>
+            </c:if>
+
             <div class="footer-links">
                 <a href="<c:url value='/find-id' />">아이디찾기</a>
                 <a href="<c:url value='/find-password' />">비밀번호 찾기</a>
@@ -239,7 +252,7 @@
 </div>
 
 <footer>
-     2025 WareFlow Co. All rights reserved ©
+    2025 WareFlow Co. All rights reserved ©
 </footer>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -81,6 +81,17 @@
         <servlet-name>appServlet</servlet-name>
     </filter-mapping>
 
+<!--    스프링 시큐리티 필터 적용-->
+    <filter>
+        <filter-name>springSecurityFilterChain</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>springSecurityFilterChain</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <!--
       정적 자원 매핑 설정 (CSS, JS 등)
       Maps static resources like CSS, JavaScript, and images.

--- a/src/test/java/com/buildify/wms/mapperTests/AdminLoginMapperTests.java
+++ b/src/test/java/com/buildify/wms/mapperTests/AdminLoginMapperTests.java
@@ -1,0 +1,28 @@
+package com.buildify.wms.mapperTests;
+
+import com.wareflow.buildify.domain.auth.login.mapper.AdminLoginMapper;
+import com.wareflow.buildify.vo.AdminVO;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = {
+        "file:src/main/webapp/WEB-INF/root-context.xml"
+})
+@MapperScan(basePackages = "com.wareflow.buildify.domain.auth.login.mapper")
+@Log4j2
+public class AdminLoginMapperTests {
+    @Autowired
+    private AdminLoginMapper adminLoginMapper;
+
+    @Test
+    public void testFindByUsername() {
+        AdminVO adminVO = adminLoginMapper.findById("admin001");
+        log.info("admin : " + adminVO.toString());
+    }
+}

--- a/src/test/java/com/buildify/wms/mapperTests/AuthMapperTests.java
+++ b/src/test/java/com/buildify/wms/mapperTests/AuthMapperTests.java
@@ -1,0 +1,29 @@
+package com.buildify.wms.mapperTests;
+
+import com.wareflow.buildify.domain.auth.login.mapper.AuthMapper;
+import com.wareflow.buildify.vo.AuthVO;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = {
+        "file:src/main/webapp/WEB-INF/root-context.xml"
+})
+@MapperScan(basePackages = "com.wareflow.buildify.domain.auth.login.mapper")
+@Log4j2
+public class AuthMapperTests {
+
+    @Autowired
+    private AuthMapper authMapper;
+
+    @Test
+    public void testFindById() {
+        AuthVO authVO = authMapper.findById("ehdzl3451");
+        log.info("---------------" + authVO);
+    }
+}

--- a/src/test/java/com/buildify/wms/mapperTests/UserLoginMapperTests.java
+++ b/src/test/java/com/buildify/wms/mapperTests/UserLoginMapperTests.java
@@ -1,0 +1,29 @@
+package com.buildify.wms.mapperTests;
+
+import com.wareflow.buildify.domain.auth.login.mapper.UserLoginMapper;
+import com.wareflow.buildify.vo.UserVO;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = {
+        "file:src/main/webapp/WEB-INF/root-context.xml"
+})
+@MapperScan(basePackages = "com.wareflow.buildify.domain.auth.login.mapper")
+@Log4j2
+public class UserLoginMapperTests {
+
+    @Autowired
+    private UserLoginMapper userLoginMapper;
+
+    @Test
+    public void testUserLoginMapper() {
+        UserVO userVO = userLoginMapper.findById("ehdgnl3546");
+        log.info("uservo ------------- : " + userVO.toString());
+    }
+}

--- a/src/test/java/com/buildify/wms/serviceTests/CustomUserDetailsServiceTests.java
+++ b/src/test/java/com/buildify/wms/serviceTests/CustomUserDetailsServiceTests.java
@@ -1,0 +1,33 @@
+package com.buildify.wms.serviceTests;
+
+import com.wareflow.buildify.domain.auth.login.security.CustomUserDetailsService;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = {
+        "file:src/main/webapp/WEB-INF/root-context.xml"
+})
+@MapperScan(basePackages = "com.wareflow.buildify.domain.auth.login.mapper")
+@Log4j2
+public class CustomUserDetailsServiceTests {
+
+    @Autowired
+    private CustomUserDetailsService userDetailsService;
+
+    @Test
+    public void testLoadUserByUsername() {
+        String testId = "admin001"; // 실제 존재하는 auth id
+        UserDetails userDetails = userDetailsService.loadUserByUsername(testId);
+
+        log.info("✅ 사용자 ID: {}", userDetails.getUsername());
+        log.info("✅ 비밀번호(암호화): {}", userDetails.getPassword());
+        log.info("✅ 권한 목록: {}", userDetails.getAuthorities());
+    }
+}


### PR DESCRIPTION
### 🔧 작업 내용
- [x] 허용하지 않은 페이지 이외에는 모두 시큐리티 인증이 필요함 (현재는 풀어놓음)
- [x] 로그인 -> auth 테이블에서 id, role 조회 -> user 혹은 admin 테이블에서 id pw 비교 로직
- [x] 스프링 시큐리티에도 role을 지원해서 현재 시큐리티 로직에 유저/어드민 나누어져있음
- [x] user / admin 로그인 이후 연결될 컨트롤러(url) 정의 
- [x]  로그인 이후 타 도메인의 컨트롤러에서 유저 혹은 어드민 정보를 가져다 쓸 수 있게 
- [x] 시큐리티 config 현재 스프링 버전과 호환되게 구현 변경

### 📌 참고 사항
- [x] 개발하면서 mapper.xml 작성시 vo 와 데이터 필드가 안맞을 때 가 있음 (카멜케이스 이슈) mybatis-config.xml 세팅 파일로 문제 해결
- [x] 현재는 개발에 혼선이 있을 수 있어서  .requestMatchers("/**").permitAll() 처리 즉, 어떤 페이지도 인증없이 접근 가능한 상태 (별도의 프로퍼티 파일로 컨트롤 필요함)

